### PR TITLE
normalize_path and add_include_path now accept strings

### DIFF
--- a/sw_mc_builder/_utils.py
+++ b/sw_mc_builder/_utils.py
@@ -30,7 +30,7 @@ BUILDER_IDENTIFIER: str = "Built with sw_mc_builder version 1"
 INCLUDE_PATHS: list[Path] = [MAIN_PATH]
 
 
-def normalize_path(path: Path) -> Path:
+def normalize_path(path: str | Path) -> Path:
     """
     Normalize a path by resolving it and converting it to an absolute path.
     """
@@ -43,7 +43,7 @@ def normalize_path(path: Path) -> Path:
     raise FileNotFoundError(f"Could not find path: {path}")
 
 
-def add_include_path(path: Path) -> None:
+def add_include_path(path: str | Path) -> None:
     """
     Add a path to the list of include paths for resolving scripts and script dependencies.
     """

--- a/sw_mc_builder/script_handling.py
+++ b/sw_mc_builder/script_handling.py
@@ -1,6 +1,5 @@
 import sys
 from functools import cache
-from pathlib import Path
 
 import tumfl
 
@@ -33,7 +32,7 @@ def resolve_and_verify_script(script_path: str) -> str:
     Resolve dependencies in the given script and verify its correctness.
     """
     try:
-        ast = tumfl.resolve_recursive(normalize_path(Path(script_path)), INCLUDE_PATHS)
+        ast = tumfl.resolve_recursive(normalize_path(script_path), INCLUDE_PATHS)
     except tumfl.error.TumflError as e:
         if isinstance(e, tumfl.error.ParserError):
             print(e.full_error)


### PR DESCRIPTION
This is mainly a convenience change, as you oftentimes want to just give it a file name.